### PR TITLE
Fixed IOptProblem GetMaxValue

### DIFF
--- a/src/IOptProblem.cpp
+++ b/src/IOptProblem.cpp
@@ -56,7 +56,7 @@ vector<double> IOptProblem::GetMaxPoint() const
 }
 
 // ------------------------------------------------------------------------------------------------
-double IOptProblem::GetMaxValue(int index) const
+double IOptProblem::GetMaxValue() const
 {
   return IGeneralOptProblem::GetMaxValue(mFunctionIndex);
 }

--- a/src/IOptProblem.hpp
+++ b/src/IOptProblem.hpp
@@ -26,7 +26,7 @@ public:
   /// Get global maximizer
   vector<double> GetMaxPoint() const;
   /// Get global maximum value
-  double GetMaxValue(int index) const;
+  double GetMaxValue() const;
   /// Get the value of Lipschitz constant
   double GetLipschitzConstant() const;
 


### PR DESCRIPTION
Index of function has already been stored as protected value mFunctionIndex. And parameter _index_ is not being used.